### PR TITLE
Add support for no_std builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ categories = ["network-programming", "no-std", "parser-implementations"]
 
 [features]
 default = ["std"]
-std = []
+std = ["byteorder/std", "memchr/std"]
 
 [dependencies]
-byteorder = "1.4"
+byteorder = { version = "1.4", default-features = false }
 bitflags = "1.3"
-memchr = "2.4"
+memchr = { version = "2.4", default-features = false }
 ref-cast = "1.0"


### PR DESCRIPTION
Both byteorder and memchr have their `std` features enabled by default, opting out of default features allows building for no_std targets.
